### PR TITLE
feat: 레포페이지 다이나믹 라우팅으로 변경

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,7 +27,6 @@ export default function HomePage() {
   const [selectedRepo, setSelectedRepo] = useState<string>("");
 
   useEffect(() => {
-    // 인증 상태 확인 후 로그인 페이지로 리다이렉트
     if (isInitialized && !isAuthenticated) {
       router.push("/login");
     }
@@ -61,11 +60,10 @@ export default function HomePage() {
 
   const handleRepoSelect = () => {
     if (selectedRepo) {
-      router.push(`/repo?repoName=${selectedRepo}`);
+      router.push(`/repo/${encodeURIComponent(selectedRepo)}`);
     }
   };
 
-  // 로딩 중 표시
   if (!isInitialized || loading) {
     return (
       <div className="flex min-h-screen flex-col items-center justify-center bg-gray-50">
@@ -191,36 +189,24 @@ export default function HomePage() {
             </div>
             <div className="space-y-4">
               <div className="flex items-start gap-8 rounded-lg bg-blue-50 p-10">
-                <div className="flex size-5 shrink-0 items-center justify-center rounded-full font-semibold text-blue-800">
-                  1
-                </div>
                 <p className="text-gray-700">
                   <b>레포지토리 선택:</b> 분석하고 싶은 GitHub 레포지토리를
                   선택하세요.
                 </p>
               </div>
               <div className="flex items-start gap-8 rounded-lg bg-blue-50 p-10">
-                <div className="flex size-5 shrink-0 items-center justify-center rounded-fullfont-semibold text-blue-800">
-                  2
-                </div>
                 <p className="text-gray-700">
                   <b>파일 선택:</b> 레포지토리에서 학습하고 싶은 파일을
                   선택하세요.
                 </p>
               </div>
               <div className="flex items-start gap-8 rounded-lg bg-blue-50 p-10">
-                <div className="flex size-5 shrink-0 items-center justify-center rounded-full font-semibold text-blue-800">
-                  3
-                </div>
                 <p className="text-gray-700">
                   <b>AI 분석:</b> AI가 코드를 분석하고 학습 노트와 퀴즈를
                   생성합니다.
                 </p>
               </div>
               <div className="flex items-start gap-8 rounded-lg bg-blue-50 p-10">
-                <div className="flex size-5 shrink-0 items-center justify-center rounded-full font-semibold text-blue-800">
-                  4
-                </div>
                 <p className="text-gray-700">
                   <b>학습 및 복습:</b> 자동 생성된 퀴즈로 학습 내용을
                   복습하세요.
@@ -231,9 +217,9 @@ export default function HomePage() {
         </div>
 
         {/* 최근 학습 노트 */}
-        <div className="mt-10">
+        <div className="mt-15">
           <div className="mb-6 flex items-center gap-2 text-20-700 text-gray-900">
-            <LuClipboardList className="size-6 text-blue-600" />
+            <LuClipboardList className="size-18 text-blue-600" />
             최근 학습 노트
           </div>
 
@@ -253,7 +239,7 @@ export default function HomePage() {
                     <span className="text-13-500 text-gray-500">
                       {note.fileName}
                     </span>
-                    <span className="rounded-full bg-blue-100 px-2 py-1 text-12-600 text-blue-700">
+                    <span className="rounded-full bg-blue-100 px-2 py-5 text-12-600 text-blue-700">
                       {note.fileType === "code" ? "코드" : "문서"}
                     </span>
                   </div>
@@ -274,7 +260,7 @@ export default function HomePage() {
                     : undefined
                 }
                 disabled={!selectedRepo}
-                className={`mt-4 rounded-md px-4 py-2 text-14-600 text-white ${
+                className={`mt-4 rounded-md px-6 py-7 text-14-600 text-white ${
                   selectedRepo ? "bg-blue-600 hover:bg-blue-700" : "bg-gray-400"
                 }`}
               >

--- a/src/app/repo/[repoName]/page.tsx
+++ b/src/app/repo/[repoName]/page.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Suspense } from "react";
+import { LuLoader } from "react-icons/lu";
+
+import RepoHeader from "@/components/repo/RepoHeader";
+import RepositoryExplorer from "@/components/repo/RepositoryExplorer";
+
+interface RepoPageProps {
+  params: {
+    repoName: string;
+  };
+}
+function LoadingState() {
+  return (
+    <div className="flex min-h-96 items-center justify-center">
+      <LuLoader className="size-8 animate-spin text-blue-600" />
+      <span className="ml-2 text-gray-600">레포지토리를 불러오는 중...</span>
+    </div>
+  );
+}
+
+export default function RepoPage({ params }: RepoPageProps) {
+  const repoFullName = decodeURIComponent(params.repoName);
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <RepoHeader repoFullName={repoFullName} />
+
+        <div className="shadow mt-8 overflow-hidden rounded-lg bg-white">
+          <Suspense fallback={<LoadingState />}>
+            <RepositoryExplorer repoFullName={repoFullName} />
+          </Suspense>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/repo/page.tsx
+++ b/src/app/repo/page.tsx
@@ -1,21 +1,24 @@
-import RepositoryExplorer from "@/components/repo/RepositoryExplorer";
+"use client";
 
-export default function ReposPage() {
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+
+export default function RepoRedirectPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const repoName = searchParams.get("repoName");
+
+  useEffect(() => {
+    if (repoName) {
+      router.replace(`/repo/${encodeURIComponent(repoName)}`);
+    } else {
+      router.replace("/");
+    }
+  }, [repoName, router]);
+
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="mb-8">
-          <div className="text-20-700 tracking-tight text-gray-900">
-            DevMate
-          </div>
-          <p className="mt-8 text-14-600 text-gray-600">
-            파일을 고르고 AI에게 분석을 맡기세요
-          </p>
-        </div>
-        <div className="shadow overflow-hidden rounded-lg bg-white">
-          <RepositoryExplorer />
-        </div>
-      </div>
+    <div className="flex h-screen items-center justify-center">
+      <p className="text-gray-500">레포지토리 이동중...</p>
     </div>
   );
 }

--- a/src/app/repo/page.tsx
+++ b/src/app/repo/page.tsx
@@ -1,24 +1,18 @@
-"use client";
+// src/app/repo/page.tsx
+import { redirect } from "next/navigation";
 
-import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect } from "react";
+interface RepoPageProps {
+  searchParams: {
+    repoName?: string;
+  };
+}
 
-export default function RepoRedirectPage() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const repoName = searchParams.get("repoName");
+export default function RepoPage({ searchParams }: RepoPageProps) {
+  const { repoName } = searchParams;
 
-  useEffect(() => {
-    if (repoName) {
-      router.replace(`/repo/${encodeURIComponent(repoName)}`);
-    } else {
-      router.replace("/");
-    }
-  }, [repoName, router]);
-
-  return (
-    <div className="flex h-screen items-center justify-center">
-      <p className="text-gray-500">레포지토리 이동중...</p>
-    </div>
-  );
+  if (repoName) {
+    redirect(`/repo/${encodeURIComponent(repoName)}`);
+  } else {
+    redirect("/");
+  }
 }

--- a/src/components/repo/RepoHeader.tsx
+++ b/src/components/repo/RepoHeader.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import {
+  LuArrowLeft,
+  LuBookOpen,
+  LuChevronsUpDown,
+  LuGithub,
+  LuStar,
+} from "react-icons/lu";
+
+import useGitHubAuth from "@/hooks/use-auth";
+import githubApi from "@/lib/github";
+import { Repository } from "@/types/github";
+
+interface RepoHeaderProps {
+  repoFullName: string;
+}
+
+export default function RepoHeader({ repoFullName }: RepoHeaderProps) {
+  const router = useRouter();
+  const { token } = useGitHubAuth();
+  const [repoData, setRepoData] = useState<Repository | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [showRepoSelector, setShowRepoSelector] = useState(false);
+  const [repositories, setRepositories] = useState<Repository[]>([]);
+
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    async function fetchRepoDetails() {
+      if (!token || !repoFullName) return;
+
+      try {
+        setLoading(true);
+        const [owner, repo] = repoFullName.split("/");
+        const response = await fetch(
+          `https://api.github.com/repos/${owner}/${repo}`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+              Accept: "application/vnd.github.v3+json",
+            },
+          },
+        );
+
+        if (!response.ok) {
+          throw new Error("레포지토리 정보를 가져오는데 실패했습니다");
+        }
+
+        const data = await response.json();
+        setRepoData(data);
+
+        const allRepos = await githubApi.getUserRepos(token);
+        setRepositories(allRepos);
+      } catch (error) {
+        console.error("레포지토리 정보 가져오기 오류:", error); //eslint-disable-line
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchRepoDetails();
+  }, [repoFullName, token]);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        buttonRef.current &&
+        !dropdownRef.current.contains(event.target as Node) &&
+        !buttonRef.current.contains(event.target as Node)
+      ) {
+        setShowRepoSelector(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  const handleRepoChange = (newRepoFullName: string) => {
+    if (newRepoFullName && newRepoFullName !== repoFullName) {
+      router.push(`/repo/${encodeURIComponent(newRepoFullName)}`);
+    }
+    setShowRepoSelector(false);
+  };
+
+  return (
+    <div>
+      <div className="mb-10 flex items-center">
+        <button
+          type="button"
+          onClick={() => router.push("/")}
+          className="flex items-center text-16-500 text-blue-600 hover:text-blue-800"
+        >
+          <LuArrowLeft className="mr-1 size-25" />
+          홈으로 돌아가기
+        </button>
+      </div>
+
+      <div className="shadow-sm flex flex-col items-start justify-between gap-4 rounded-lg bg-white p-6 md:flex-row md:items-center">
+        <div className="flex items-center">
+          <LuGithub className="size-40" />
+
+          <div className="ml-8">
+            <div className="relative">
+              <button
+                ref={buttonRef}
+                type="button"
+                onClick={() => setShowRepoSelector(!showRepoSelector)}
+                className="flex items-center text-24-700 text-gray-900 hover:text-blue-600"
+              >
+                {repoFullName}
+                <LuChevronsUpDown className="ml-5 size-15" />
+              </button>
+
+              {showRepoSelector && (
+                <div
+                  ref={dropdownRef}
+                  className="shadow-lg absolute z-10 mt-1 max-h-106 w-full overflow-auto rounded-md border border-gray-200 bg-white"
+                >
+                  <div className="p-1">
+                    {repositories.map((repo) => (
+                      <button
+                        type="button"
+                        key={repo.id}
+                        className={`w-full px-4 py-2 text-left text-14-500 hover:bg-gray-100 ${
+                          repo.full_name === repoFullName
+                            ? "bg-blue-50 text-blue-600"
+                            : "text-gray-900"
+                        }`}
+                        onClick={() => handleRepoChange(repo.full_name)}
+                      >
+                        {repo.full_name}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div className="mt-1 flex items-center text-14-500 text-gray-500">
+              {!loading && repoData && (
+                <>
+                  <span className="flex items-center">
+                    <LuStar className="mr-1 size-15" />
+                    {repoData.stargazers_count} 스타
+                  </span>
+                  {repoData.language && (
+                    <span className="ml-4 flex items-center">
+                      {repoData.language}
+                    </span>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex w-full flex-wrap gap-5 md:w-auto">
+          <Link
+            href={`https://github.com/${repoFullName}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center rounded-md border border-gray-300 bg-white px-8 py-10 text-16-600 text-gray-700 hover:bg-gray-50"
+          >
+            <LuGithub className="mr-4 size-15" />
+            GitHub에서 보기
+          </Link>
+          <button
+            type="button"
+            className="flex items-center rounded-md border border-gray-300 px-8 py-10 text-16-600 hover:bg-blue-100"
+          >
+            <LuBookOpen className="mr-4 size-15" />
+            학습 노트 모아보기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/repo/RepositoryExplorer/FileExplorer.tsx
+++ b/src/components/repo/RepositoryExplorer/FileExplorer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { LuSearch } from "react-icons/lu";
 
 import useGitHubAuth from "@/hooks/use-auth";
 import githubApi from "@/lib/github";
@@ -10,17 +11,22 @@ import Breadcrumbs from "./Breadcrumbs";
 import FileListItem from "./FileListItem";
 import LoadingState from "./LoadingState";
 
-interface Props {
+interface FileExplorerProps {
   repoFullName: string;
   onFileSelect: (file: RepoItem, content: string) => void;
 }
 
-export default function FileExplorer({ repoFullName, onFileSelect }: Props) {
+export default function FileExplorer({
+  repoFullName,
+  onFileSelect,
+}: FileExplorerProps) {
   const { token } = useGitHubAuth();
   const [contents, setContents] = useState<RepoItem[]>([]);
   const [breadcrumbs, setBreadcrumbs] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState<string>("");
+  const [selectedFilePath, setSelectedFilePath] = useState<string | null>(null);
 
   const fetchContents = async (path: string) => {
     if (!token || !repoFullName) return;
@@ -60,6 +66,7 @@ export default function FileExplorer({ repoFullName, onFileSelect }: Props) {
         await fetchContents(item.path);
       } else {
         setLoading(true);
+        setSelectedFilePath(item.path);
         const [owner, repo] = repoFullName.split("/");
         const content = await githubApi.getFileContent(
           token,
@@ -97,12 +104,32 @@ export default function FileExplorer({ repoFullName, onFileSelect }: Props) {
     }
   };
 
+  // 검색어에 따라 파일 필터링
+  const filteredContents = contents.filter((item) =>
+    item.name.toLowerCase().includes(searchTerm.toLowerCase()),
+  );
+
   if (loading) {
     return <LoadingState />;
   }
 
   return (
-    <div className="rounded-lg border border-gray-200 bg-white">
+    <div className="h-full">
+      <div className="border-b border-gray-200 bg-gray-50 p-4">
+        <div className="relative">
+          <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+            <LuSearch className="size-15 text-gray-400" />
+          </div>
+          <input
+            type="text"
+            className="block w-full rounded-lg border border-gray-300 bg-white py-5 pl-20 pr-3 text-14-500 placeholder:text-gray-500 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            placeholder="파일 검색..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+          />
+        </div>
+      </div>
+
       <Breadcrumbs items={breadcrumbs} onNavigate={handleBreadcrumbClick} />
 
       {errorMessage && (
@@ -111,22 +138,27 @@ export default function FileExplorer({ repoFullName, onFileSelect }: Props) {
         </div>
       )}
 
-      {contents.length === 0 ? (
-        <div className="p-8 text-center text-gray-500">
-          This directory is empty
-        </div>
-      ) : (
-        <div className="divide-y divide-gray-200">
-          {contents.map((item) => (
-            <FileListItem
-              key={item.path}
-              item={item}
-              onClick={handleFileClick}
-              isLoading={loading}
-            />
-          ))}
-        </div>
-      )}
+      <div className="h-[calc(100vh-20rem)] overflow-y-auto">
+        {filteredContents.length === 0 ? (
+          <div className="p-8 text-center text-gray-500">
+            {searchTerm
+              ? "검색 결과가 없습니다."
+              : "이 디렉토리는 비어있습니다."}
+          </div>
+        ) : (
+          <div className="divide-y divide-gray-100">
+            {filteredContents.map((item) => (
+              <FileListItem
+                key={item.path}
+                item={item}
+                onClick={handleFileClick}
+                isLoading={loading}
+                isSelected={item.path === selectedFilePath}
+              />
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/repo/RepositoryExplorer/FileListItem.tsx
+++ b/src/components/repo/RepositoryExplorer/FileListItem.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { LuFileJson2, LuFolderCode } from "react-icons/lu";
+import { LuChevronRight, LuFileJson2, LuFolderCode } from "react-icons/lu";
 
 import { RepoItem } from "@/types/github";
 
@@ -7,12 +7,14 @@ interface FileListItemProps {
   item: RepoItem;
   onClick: (item: RepoItem) => void;
   isLoading: boolean;
+  isSelected?: boolean;
 }
 
 export default function FileListItem({
   item,
   onClick,
   isLoading,
+  isSelected = false,
 }: FileListItemProps) {
   return (
     <button
@@ -20,16 +22,22 @@ export default function FileListItem({
       onClick={() => onClick(item)}
       disabled={isLoading}
       className={clsx(
-        "flex w-full items-center space-x-3 px-4 py-3 text-left",
+        "flex w-full items-center justify-between px-4 py-3 text-left",
+        isSelected && "bg-blue-50",
         isLoading ? "cursor-not-allowed opacity-50" : "hover:bg-gray-50",
       )}
     >
-      {item.type === "dir" ? (
-        <LuFolderCode className="size-15 text-blue-500" />
-      ) : (
-        <LuFileJson2 className="size-15 text-gray-500" />
+      <div className="flex items-center">
+        {item.type === "dir" ? (
+          <LuFolderCode className="size-15 text-blue-500" />
+        ) : (
+          <LuFileJson2 className="size-15 text-gray-500" />
+        )}
+        <span className="ml-3 text-14-500 text-gray-900">{item.name}</span>
+      </div>
+      {item.type === "dir" && (
+        <LuChevronRight className="size-15 text-gray-400" />
       )}
-      <span>{item.name}</span>
     </button>
   );
 }

--- a/src/components/repo/RepositoryExplorer/FileViewer.tsx
+++ b/src/components/repo/RepositoryExplorer/FileViewer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import clsx from "clsx";
 import { useEffect, useState } from "react";
-import { LuFileJson2 } from "react-icons/lu";
+import { LuBrain, LuCode, LuFileJson2 } from "react-icons/lu";
 
 import LoadingProgress from "@/components/common/LoadingState";
 import useGitHubAuth from "@/hooks/use-auth";
@@ -30,10 +31,9 @@ export default function FileViewer({
 
   // 파일이 변경될 때마다 분석 결과 초기화
   useEffect(() => {
-    // 파일이 변경되면 분석 결과 초기화
     setAnalysis(null);
     setError(null);
-  }, [file.path]); // file.path가 변경될 때만 실행
+  }, [file.path]);
 
   // 파일 타입 확인 함수
   const getFileType = (fileName: string): "markdown" | "code" => {
@@ -42,6 +42,26 @@ export default function FileViewer({
   };
 
   const fileType = getFileType(file.name);
+
+  // 파일 아이콘 선택 함수
+  const getFileIcon = () => {
+    const extension = file.name.split(".").pop()?.toLowerCase() || "";
+
+    if (["js", "jsx", "ts", "tsx"].includes(extension)) {
+      return <LuCode className="ml-5 mr-10 size-25 text-yellow-500" />;
+    }
+    if (["html", "css", "scss"].includes(extension)) {
+      return <LuFileJson2 className="ml-5 mr-10 size-25 text-blue-500" />;
+    }
+    if (["md", "txt"].includes(extension)) {
+      return <LuFileJson2 className="ml-5 mr-10 size-25 text-green-500" />;
+    }
+    if (["json", "yaml", "yml", "toml"].includes(extension)) {
+      return <LuFileJson2 className="ml-5 mr-10 size-25 text-purple-500" />;
+    }
+
+    return <LuFileJson2 className="ml-5 mr-10 size-25 text-gray-500" />;
+  };
 
   const handleAnalyze = async () => {
     try {
@@ -137,18 +157,22 @@ export default function FileViewer({
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex items-center justify-between border-b border-gray-200 p-4">
-        <div className="flex items-center space-x-2">
-          <LuFileJson2 className="size-15 text-gray-400" />
-          <div>
-            <h3 className="font-medium text-gray-900">{file.name}</h3>
+      <div className="flex items-center justify-between border-b border-gray-200 bg-gray-50 p-4">
+        <div className="flex items-center">
+          {getFileIcon()}
+          <div className="ml-3">
+            <h3 className="text-16-700 text-gray-900">{file.name}</h3>
+            <p className="mt-1 text-12-500 text-gray-500">
+              {fileType === "code" ? "코드 파일" : "문서 파일"}
+            </p>
           </div>
         </div>
         <button
           type="button"
           onClick={handleAnalyze}
-          className="shadow-sm inline-flex items-center rounded-md bg-blue-600 px-8 py-5 text-14-600 text-white hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          className="shadow-sm flex items-center rounded-md bg-blue-600 px-4 py-5 text-14-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
         >
+          <LuBrain className="mr-2 size-15" />
           AI 분석하기
         </button>
       </div>
@@ -159,16 +183,18 @@ export default function FileViewer({
         </div>
       )}
 
-      <div className="flex-1 overflow-auto p-4">
-        <pre className="rounded-lg bg-gray-50 p-4 text-14-500">
-          <code className="whitespace-pre-wrap font-mono text-gray-800">
-            {content}
-          </code>
-        </pre>
+      <div className="flex-1 overflow-auto">
+        <div className="h-[calc(100vh-20rem)] overflow-y-auto p-4">
+          <pre className={clsx("rounded-lg p-4 text-14-500", "bg-gray-50")}>
+            <code className="whitespace-pre-wrap font-mono text-gray-800">
+              {content}
+            </code>
+          </pre>
+        </div>
       </div>
 
       {/* 로딩 진행 표시기 */}
-      <LoadingProgress stage={analysisStage} isLoading={loading} />
+      {loading && <LoadingProgress stage={analysisStage} isLoading />}
     </div>
   );
 }

--- a/src/components/repo/RepositoryExplorer/index.tsx
+++ b/src/components/repo/RepositoryExplorer/index.tsx
@@ -7,55 +7,49 @@ import { RepoItem } from "@/types/github";
 
 import FileExplorer from "./FileExplorer";
 import FileViewer from "./FileViewer";
-import RepositorySelector from "./RepositorySelector";
 
-export default function RepositoryExplorer() {
-  const [selectedRepo, setSelectedRepo] = useState<string | null>(null);
+interface RepositoryExplorerProps {
+  repoFullName: string;
+}
+
+export default function RepositoryExplorer({
+  repoFullName,
+}: RepositoryExplorerProps) {
   const [selectedFile, setSelectedFile] = useState<RepoItem | null>(null);
   const [fileContent, setFileContent] = useState<string | null>(null);
 
   return (
-    <div className="divide-y divide-gray-200">
-      <div className="p-6">
-        <RepositorySelector
-          selectedRepo={selectedRepo}
-          onSelect={setSelectedRepo}
+    <div className="grid grid-cols-1 divide-y divide-gray-200 lg:grid-cols-2 lg:divide-x lg:divide-y-0">
+      <div className="lg:min-h-[calc(100vh-20rem)]">
+        <FileExplorer
+          repoFullName={repoFullName}
+          onFileSelect={(file, content) => {
+            setSelectedFile(file);
+            setFileContent(content);
+          }}
         />
       </div>
-      {selectedRepo && (
-        <div className="grid grid-cols-1 divide-y divide-gray-200 lg:grid-cols-2 lg:divide-x lg:divide-y-0">
-          <div className="lg:min-h-[calc(100vh-16rem)]">
-            <FileExplorer
-              repoFullName={selectedRepo}
-              onFileSelect={(file, content) => {
-                setSelectedFile(file);
-                setFileContent(content);
-              }}
-            />
+      <div className="lg:min-h-[calc(100vh-20rem)]">
+        {selectedFile ? (
+          <FileViewer
+            file={selectedFile}
+            repoName={repoFullName}
+            content={fileContent}
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center p-6 text-center text-gray-500">
+            <div>
+              <LuFileJson2 className="mx-auto size-16 text-gray-400" />
+              <h3 className="mt-4 text-16-600 text-gray-900">
+                파일을 선택해주세요
+              </h3>
+              <p className="mt-2 text-14-500 text-gray-500">
+                왼쪽 파일 탐색기에서 분석하고 싶은 파일을 선택하세요
+              </p>
+            </div>
           </div>
-          <div className="lg:min-h-[calc(100vh-16rem)]">
-            {selectedFile ? (
-              <FileViewer
-                file={selectedFile}
-                repoName={selectedRepo} // 필수 prop 추가
-                content={fileContent}
-              />
-            ) : (
-              <div className="flex h-full items-center justify-center p-6 text-center text-gray-500">
-                <div>
-                  <LuFileJson2 className="mx-auto size-30 text-gray-400" />
-                  <h3 className="mt-2 text-14-600 text-gray-900">
-                    선택된 파일이 없습니다.
-                  </h3>
-                  <p className="mt-1 text-14-500 text-gray-500">
-                    파일을 고르고 확인하세요!!
-                  </p>
-                </div>
-              </div>
-            )}
-          </div>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## #️⃣ 이슈

- close #21 

## 📝 작업 내용

- 레포지토리페이지 수정
- 레포지토리페이지 다이나믹 라우팅으로 변경
- 레포짙지토리 파일 검색기능 추가

## 📸 스크린샷

[12e3s.webm](https://github.com/user-attachments/assets/4bd4cbd1-a286-4eff-9d0a-78c043784651)


## ✅ 체크 리스트

- [x] 적절한 Title 작성
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정
- [x] 로컬 작동 확인
- [x] Merge 되는 브랜치 확인

## 👩‍💻 공유 포인트 및 논의 사항

<!-- 공유하거나 논의할 사항을 작성해주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 추가된 리포지토리 상세 페이지와 헤더로 GitHub 리포지토리 정보를 한눈에 확인할 수 있습니다.
	- 파일 탐색기에서 검색 기능 및 파일 타입에 따른 아이콘 표시, AI 분석 버튼 등의 기능이 새롭게 도입되었습니다.
  
- **Refactor**
	- 라우팅 및 네비게이션 로직이 개선되어 선택된 리포지토리로의 이동이 보다 원활해졌습니다.
	- 리포지토리 및 파일 탐색 흐름을 간소화하여 사용자 경험이 강화되었습니다.

- **Style**
	- 여백, 패딩, 아이콘 크기 등 UI 요소가 조정되어 보다 깔끔하고 직관적인 레이아웃을 제공합니다.
	- 불필요한 안내 번호 등이 제거되어 화면 구성이 한층 간결해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->